### PR TITLE
Degeneralize recv

### DIFF
--- a/crates/crystalorb-bevy-networking-turbulence/src/lib.rs
+++ b/crates/crystalorb-bevy-networking-turbulence/src/lib.rs
@@ -31,7 +31,7 @@ pub use crystalorb;
 pub struct WrappedNetworkResource<'a>(pub &'a mut NetworkResource);
 pub struct WrappedConnection<'a>(pub &'a mut MessageChannels);
 
-impl<'a> NetworkResourceTrait for WrappedNetworkResource<'a> {
+impl<'a, WorldType: World> NetworkResourceTrait<WorldType> for WrappedNetworkResource<'a> {
     type ConnectionType<'b> = WrappedConnection<'b>;
 
     fn get_connection(&mut self, handle: ConnectionHandleType) -> Option<Self::ConnectionType<'_>> {
@@ -53,11 +53,16 @@ impl<'a> NetworkResourceTrait for WrappedNetworkResource<'a> {
     }
 }
 
-impl<'a> ConnectionTrait for WrappedConnection<'a> {
-    fn recv<MessageType>(&mut self) -> Option<MessageType>
-    where
-        MessageType: Debug + Clone + Serialize + DeserializeOwned + Send + Sync + 'static,
-    {
+impl<'a, WorldType: World> ConnectionTrait<WorldType> for WrappedConnection<'a> {
+    fn recv_command(&mut self) -> Option<Timestamped<WorldType::CommandType>> {
+        self.0.recv()
+    }
+
+    fn recv_snapshot(&mut self) -> Option<Timestamped<WorldType::SnapshotType>> {
+        self.0.recv()
+    }
+
+    fn recv_clock_sync(&mut self) -> Option<ClockSyncMessage> {
         self.0.recv()
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -143,7 +143,7 @@ impl<WorldType: World> Client<WorldType> {
     ///     # break;
     /// }
     /// ```
-    pub fn update<NetworkResourceType: NetworkResource>(
+    pub fn update<NetworkResourceType: NetworkResource<WorldType>>(
         &mut self,
         delta_seconds: f64,
         seconds_since_startup: f64,
@@ -268,7 +268,7 @@ impl<WorldType: World> ActiveClient<WorldType> {
     }
 
     /// Perform the next update for the current rendering frame.
-    pub fn update<NetworkResourceType: NetworkResource>(
+    pub fn update<NetworkResourceType: NetworkResource<WorldType>>(
         &mut self,
         delta_seconds: f64,
         seconds_since_startup: f64,
@@ -278,10 +278,10 @@ impl<WorldType: World> ActiveClient<WorldType> {
             .update(delta_seconds, seconds_since_startup, net);
 
         for (_, mut connection) in net.connections() {
-            while let Some(command) = connection.recv::<Timestamped<WorldType::CommandType>>() {
+            while let Some(command) = connection.recv_command() {
                 self.timekeeping_simulations.receive_command(&command);
             }
-            while let Some(snapshot) = connection.recv::<Timestamped<WorldType::SnapshotType>>() {
+            while let Some(snapshot) = connection.recv_snapshot() {
                 self.timekeeping_simulations.receive_snapshot(snapshot);
             }
         }

--- a/src/client/stage.rs
+++ b/src/client/stage.rs
@@ -78,7 +78,7 @@ pub(crate) enum StageOwned<WorldType: World> {
 }
 
 impl<WorldType: World> StageOwned<WorldType> {
-    pub fn update<NetworkResourceType: NetworkResource>(
+    pub fn update<NetworkResourceType: NetworkResource<WorldType>>(
         &mut self,
         delta_seconds: f64,
         seconds_since_startup: f64,

--- a/src/client/stage/ready.rs
+++ b/src/client/stage/ready.rs
@@ -138,7 +138,7 @@ where
 {
     /// Issue a command from this client's player to the world. The command will be scheduled
     /// to the current simulating timestamp (the previously completed timestamp + 1).
-    pub fn issue_command<NetworkResourceType: NetworkResource>(
+    pub fn issue_command<NetworkResourceType: NetworkResource<WorldType>>(
         &mut self,
         command: WorldType::CommandType,
         net: &mut NetworkResourceType,

--- a/src/clocksync.rs
+++ b/src/clocksync.rs
@@ -10,6 +10,7 @@
 
 use crate::{
     network_resource::{Connection, NetworkResource},
+    world::World,
     Config,
 };
 use serde::{Deserialize, Serialize};
@@ -93,7 +94,7 @@ impl ClockSyncer {
     /// # Panics
     ///
     /// Panics when the [`ClockSyncer`] receives inconsistent `client_id` values from the server.
-    pub fn update<NetworkResourceType: NetworkResource>(
+    pub fn update<WorldType: World, NetworkResourceType: NetworkResource<WorldType>>(
         &mut self,
         delta_seconds: f64,
         seconds_since_startup: f64,
@@ -113,7 +114,7 @@ impl ClockSyncer {
 
         let mut latest_server_seconds_offset: Option<f64> = None;
         for (_, mut connection) in net.connections() {
-            while let Some(sync) = connection.recv::<ClockSyncMessage>() {
+            while let Some(sync) = connection.recv_clock_sync() {
                 let received_time = seconds_since_startup;
                 let corresponding_client_time =
                     (sync.client_send_seconds_since_startup + received_time) / 2.0;

--- a/src/network_resource.rs
+++ b/src/network_resource.rs
@@ -103,11 +103,11 @@ pub trait NetworkResource<WorldType: World> {
 /// Representation of a connection to a specific remote machine that allows CrystalOrb to send and
 /// receive messages.
 pub trait Connection<WorldType: World> {
-    /// Interface for CrystalOrb to receive the next Command message.
+    /// Interface for CrystalOrb to receive the next command message.
     fn recv_command(&mut self) -> Option<Timestamped<WorldType::CommandType>>;
-    /// Interface for CrystalOrb to receive the next Snapshot message.
+    /// Interface for CrystalOrb to receive the next snapshot message.
     fn recv_snapshot(&mut self) -> Option<Timestamped<WorldType::SnapshotType>>;
-    /// Interface for CrystalOrb to receive the next ClockSync message.
+    /// Interface for CrystalOrb to receive the next clock sync message.
     fn recv_clock_sync(&mut self) -> Option<ClockSyncMessage>;
 
     /// Interface for CrystalOrb to try sending a message to the connection's destination. If

--- a/src/network_resource.rs
+++ b/src/network_resource.rs
@@ -4,6 +4,8 @@
 use serde::{de::DeserializeOwned, Serialize};
 use std::{error::Error, fmt::Debug};
 
+use crate::{clocksync::ClockSyncMessage, timestamp::Timestamped, world::World};
+
 /// Used for identifying each connection. Note that this is how the
 /// [`Server`](crate::server::Server) determines the
 /// [`client_id`](crate::client::stage::Ready::client_id) for each client, so they should be unique
@@ -32,12 +34,12 @@ pub type ConnectionHandleType = usize;
 /// [`bevy_networking_turbulence`](https://github.com/smokku/bevy_networking_turbulence) plugin. See
 /// [`crystalorb-bevy-networking-turbulence`](https://github.com/ErnWong/crystalorb/tree/crates/crystalorb-bevy-networking-turbulence)
 /// for an example for integrating with `bevy_networking_turbulence`.
-pub trait NetworkResource {
+pub trait NetworkResource<WorldType: World> {
     /// The [`Connection`] structure that CrystalOrb will use to send/receive messages from a
     /// specific remote machine. This may probably be a wrapper to a mutable reference to some
     /// connection type that is used by your external networking library of choice, in which
     /// case a generic lifetime parameter is provided here that you can use.
-    type ConnectionType<'a>: Connection;
+    type ConnectionType<'a>: Connection<WorldType>;
 
     /// Iterate through the available connections. For servers, this would be the list of current
     /// client connections that are still alive. For the client, this would only contain the
@@ -100,14 +102,13 @@ pub trait NetworkResource {
 
 /// Representation of a connection to a specific remote machine that allows CrystalOrb to send and
 /// receive messages.
-pub trait Connection {
-    /// Interface for CrystalOrb to request the next message received, if there is one.
-    ///
-    /// CrystalOrb will invoke this method with the three message types as specified in
-    /// [`NetworkResource`].
-    fn recv<MessageType>(&mut self) -> Option<MessageType>
-    where
-        MessageType: Debug + Clone + Serialize + DeserializeOwned + Send + Sync + 'static;
+pub trait Connection<WorldType: World> {
+    /// Interface for CrystalOrb to receive the next Command message.
+    fn recv_command(&mut self) -> Option<Timestamped<WorldType::CommandType>>;
+    /// Interface for CrystalOrb to receive the next Snapshot message.
+    fn recv_snapshot(&mut self) -> Option<Timestamped<WorldType::SnapshotType>>;
+    /// Interface for CrystalOrb to receive the next ClockSync message.
+    fn recv_clock_sync(&mut self) -> Option<ClockSyncMessage>;
 
     /// Interface for CrystalOrb to try sending a message to the connection's destination. If
     /// unsuccessful, the message should be returned. Otherwise, `None` should be returned.


### PR DESCRIPTION
Implementation of #7. Split recv into three functions instead of a single generic one. Includes the necessary changes to `crystalorb-mock-network` but not `crystalorb-bevy-networking-turbulence`.
