### PR TITLE
Bump codecov-action version to v2 (v1 is deprecated) and try fixing PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,6 @@ jobs:
         with:
           args: "--ignore-tests --exclude-files examples --exclude-files crates --run-types Doctests Tests"
       - uses: codecov/codecov-action@v2
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
       - uses: actions/upload-artifact@v1
         with:
           name: code-coverage-report


### PR DESCRIPTION
GitHub secrets are not available during PR checks, and the codecov token is documented to be not needed for public repos (although I had difficulty getting it to work without a token last time).

codecov-action v1 is [deprecated](https://github.com/codecov/codecov-action/blob/260aa3b4b2f265b8578bc0e721e33ebf8ff53313/README.md) and will be removed in February 2022.

Testing this PR on a different account to check to see if the `test-coverage` check works now (see #11).

Risk Areas:

- Low risk on the build Pipeline.